### PR TITLE
feat: adding `key` param for psi API key - #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This action utilizes [Google's Page Speed Insights](https://developers.google.co
 
 **Required** The name of the site to reach `https://google.com`
 
+### `key`
+
+Optional - API key (recommended for production) to use when consuming the Page Speed Insights API. This should be stored as a [Github Secret](https://docs.github.com/en/actions/reference/encrypted-secrets). You can request a key [here](https://developers.google.com/speed/docs/insights/v5/get-started)
+
 ### `strategy`
 
 Optional — Strategy to use when analyzing the page (mobile/desktop).
@@ -31,4 +35,5 @@ steps:
       url: "https://jake.partus.ch"
       threshold: 70
       strategy: mobile
+      key: ${{ secrets.APIKEY }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,8 @@ inputs:
     description: "Score to pass the PageSpeed test. Useful for setting a performance budget (default 70)."
   strategy:
     description: "Strategy to use when analyzing the page (mobile/desktop)."
+  key:
+    description: "A PageSpeed Insights API key"
 runs:
   using: "node12"
   main: "index.js"

--- a/index.js
+++ b/index.js
@@ -8,12 +8,16 @@ const run = async () => {
       core.setFailed("Url is required to run Page Speed Insights.");
       return;
     }
+
+    const key = core.getInput('key');
+
     const threshold = Number(core.getInput("threshold")) || 70;
     const strategy = core.getInput("strategy") || "mobile";
     // Output a formatted report to the terminal
     console.log(`Running Page Speed Insights for ${url}`);
     await psi.output(url, {
-      nokey: "true",
+      ...(key ? {key} : undefined),
+      ...(key ? undefined : {nokey: "true"}),
       strategy,
       format: "cli",
       threshold


### PR DESCRIPTION
Hi @JakePartusch :wave: ,

First of all, thanks for creating this action. I am going to use this action in the near future for a new project but I really need the option to add my own API key.

I went ahead and implemented a `key` param to provide your own API key for PSI. Any feedback is welcome.